### PR TITLE
Remove is_normal() DPI check to workaround emscripten/rustc bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.18.1"
+version = "0.18.2"
 authors = ["The winit contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 keywords = ["windowing"]

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -83,7 +83,7 @@
 /// otherwise, you risk panics.
 #[inline]
 pub fn validate_hidpi_factor(dpi_factor: f64) -> bool {
-    dpi_factor.is_sign_positive() && dpi_factor.is_normal()
+    dpi_factor.is_sign_positive()
 }
 
 /// A position represented in logical pixels.


### PR DESCRIPTION
rustc 1.32.0 + emscripten sdk-1.38.22-64bit:
thread 'main' panicked at 'x=2, is_sign_positive=true, is_normal=true, classify=Normal, to_bits=0x4000000000000000, ==2.0=true', normaltest.rs:3:5

rustc 1.31.0 + emscripten sdk-1.37.12-64bit:
thread 'main' panicked at 'x=2, is_sign_positive=true, is_normal=false, classify=Subnormal, to_bits=0x4000000000000000, ==2.0=true', normaltest.rs:3:5

https://github.com/tomaka/winit/issues/760#issuecomment-455806857
https://github.com/tomaka/winit/issues/760#issuecomment-455810886

